### PR TITLE
Fix Google Maps URL to work with newest version of the URL

### DIFF
--- a/CMMapLauncher/CMMapLauncher.h
+++ b/CMMapLauncher/CMMapLauncher.h
@@ -51,15 +51,16 @@ typedef NS_ENUM(NSUInteger, CMMapApp) {
     CMMapAppTheTransitApp,  // The Transit App
     CMMapAppWaze,           // Waze
     CMMapAppYandex,         // Yandex Navigator
+    CMMapAppUber,           // Uber
 };
 
 @interface CMMapLauncher : NSObject
 
 /**
  Determines whether the given mapping app is installed.
- 
+
  @param mapApp An enumeration value identifying a mapping application.
- 
+
  @return YES if the specified app is installed, NO otherwise.
  */
 + (BOOL)isMapAppInstalled:(CMMapApp)mapApp;
@@ -67,10 +68,10 @@ typedef NS_ENUM(NSUInteger, CMMapApp) {
 /**
  Launches the specified mapping application with directions
  from the user's current location to the specified endpoint.
- 
+
  @param mapApp An enumeration value identifying a mapping application.
  @param end The destination of the desired directions.
- 
+
  @return YES if the mapping app could be launched, NO otherwise.
  */
 + (BOOL)launchMapApp:(CMMapApp)mapApp
@@ -79,11 +80,11 @@ typedef NS_ENUM(NSUInteger, CMMapApp) {
 /**
  Launches the specified mapping application with directions
  between the two specified endpoints.
- 
+
  @param mapApp An enumeration value identifying a mapping application.
  @param start The starting point of the desired directions.
  @param end The destination of the desired directions.
- 
+
  @return YES if the mapping app could be launched, NO otherwise.
  */
 + (BOOL)launchMapApp:(CMMapApp)mapApp
@@ -131,14 +132,14 @@ typedef NS_ENUM(NSUInteger, CMMapApp) {
 
 /**
  Creates a new CMMapPoint with the given geographical coordinate.
- 
+
  @param coordinate The geographical coordinate of the new map point.
  */
 + (CMMapPoint *)mapPointWithCoordinate:(CLLocationCoordinate2D)coordinate;
 
 /**
  Creates a new CMMapPoint with the given name and coordinate.
- 
+
  @param name The user-visible name of the new map point.
  @param coordinate The geographical coordinate of the new map point.
  */
@@ -147,7 +148,7 @@ typedef NS_ENUM(NSUInteger, CMMapApp) {
 
 /**
  Creates a new CMMapPoint with the given name, address, and coordinate.
- 
+
  @param name The user-visible name of the new map point.
  @param address The address string of the new map point.
  @param coordinate The geographical coordinate of the new map point.
@@ -158,7 +159,7 @@ typedef NS_ENUM(NSUInteger, CMMapApp) {
 
 /**
  Creates a new CMMapPoint with the given name, address, and coordinate.
- 
+
  @param address The address string of the new map point.
  @param coordinate The geographical coordinate of the new map point.
  */

--- a/CMMapLauncher/CMMapLauncher.m
+++ b/CMMapLauncher/CMMapLauncher.m
@@ -89,7 +89,7 @@
 }
 
 + (BOOL)isMapAppInstalled:(CMMapApp)mapApp {
-    if (mapApp == CMMapAppAppleMaps || mapApp == CMMapAppUber) {
+    if (mapApp == CMMapAppAppleMaps) {
         return YES;
     }
 

--- a/CMMapLauncher/CMMapLauncher.m
+++ b/CMMapLauncher/CMMapLauncher.m
@@ -113,7 +113,7 @@
         // Check for iOS 6
         Class mapItemClass = [MKMapItem class];
         if (mapItemClass && [mapItemClass respondsToSelector:@selector(openMapsWithItems:launchOptions:)]) {
-            NSDictionary *launchOptions = @{MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDriving};
+            NSDictionary *launchOptions = @{MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeWalking};
             return [MKMapItem openMapsWithItems:@[start.MKMapItem, end.MKMapItem] launchOptions:launchOptions];
         } else {  // iOS 5
             NSString *url = [NSString stringWithFormat:@"http://maps.google.com/maps?saddr=%@&daddr=%@",

--- a/CMMapLauncher/CMMapLauncher.m
+++ b/CMMapLauncher/CMMapLauncher.m
@@ -36,22 +36,25 @@
     switch (mapApp) {
         case CMMapAppCitymapper:
             return @"citymapper://";
-            
+
         case CMMapAppGoogleMaps:
             return @"comgooglemaps://";
-            
+
         case CMMapAppNavigon:
             return @"navigon://";
-            
+
         case CMMapAppTheTransitApp:
             return @"transit://";
-            
+
         case CMMapAppWaze:
             return @"waze://";
-            
+
         case CMMapAppYandex:
             return @"yandexnavi://";
-            
+
+        case CMMapAppUber:
+            return @"uber://";
+
         default:
             return nil;
     }
@@ -61,11 +64,11 @@
     // Encode all the reserved characters, per RFC 3986
     // (<http://www.ietf.org/rfc/rfc3986.txt>)
     NSString *newString = (__bridge_transfer NSString *)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)queryParam, NULL, (CFStringRef)@"!*'();:@&=+$,/?%#[]", kCFStringEncodingUTF8);
-    
+
     if (newString) {
         return newString;
     }
-    
+
     return @"";
 }
 
@@ -73,28 +76,28 @@
     if (!mapPoint) {
         return @"";
     }
-    
+
     if (mapPoint.isCurrentLocation && mapPoint.coordinate.latitude == 0.0 && mapPoint.coordinate.longitude == 0.0) {
         return @"";
     }
-    
+
     if (mapPoint.name) {
         return [NSString stringWithFormat:@"%f,%f", mapPoint.coordinate.latitude, mapPoint.coordinate.longitude];
     }
-    
+
     return [NSString stringWithFormat:@"%f,%f", mapPoint.coordinate.latitude, mapPoint.coordinate.longitude];
 }
 
 + (BOOL)isMapAppInstalled:(CMMapApp)mapApp {
-    if (mapApp == CMMapAppAppleMaps) {
+    if (mapApp == CMMapAppAppleMaps || mapApp == CMMapAppUber) {
         return YES;
     }
-    
+
     NSString *urlPrefix = [CMMapLauncher urlPrefixForMapApp:mapApp];
     if (!urlPrefix) {
         return NO;
     }
-    
+
     return [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:urlPrefix]];
 }
 
@@ -108,12 +111,12 @@
     if (![CMMapLauncher isMapAppInstalled:mapApp]) {
         return NO;
     }
-    
+
     if (mapApp == CMMapAppAppleMaps) {
         // Check for iOS 6
         Class mapItemClass = [MKMapItem class];
         if (mapItemClass && [mapItemClass respondsToSelector:@selector(openMapsWithItems:launchOptions:)]) {
-            NSDictionary *launchOptions = @{MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDriving};
+            NSDictionary *launchOptions = @{MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeWalking};
             return [MKMapItem openMapsWithItems:@[start.MKMapItem, end.MKMapItem] launchOptions:launchOptions];
         } else {  // iOS 5
             NSString *url = [NSString stringWithFormat:@"http://maps.google.com/maps?saddr=%@&daddr=%@",
@@ -152,7 +155,7 @@
         return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];
     } else if (mapApp == CMMapAppTheTransitApp) {
         // http://thetransitapp.com/developers
-        
+
         NSMutableArray *params = [NSMutableArray arrayWithCapacity:2];
         if (start && !start.isCurrentLocation) {
             [params addObject:[NSString stringWithFormat:@"from=%f,%f", start.coordinate.latitude, start.coordinate.longitude]];
@@ -164,7 +167,7 @@
         return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];
     } else if (mapApp == CMMapAppNavigon) {
         // http://www.navigon.com/portal/common/faq/files/NAVIGON_AppInteract.pdf
-        
+
         NSString *name = @"Destination";  // Doc doesn't say whether name can be omitted
         if (end.name) {
             name = end.name;
@@ -182,8 +185,14 @@
             url = [NSString stringWithFormat:@"yandexnavi://build_route_on_map?lat_to=%f&lon_to=%f&lat_from=%f&lon_from=%f", end.coordinate.latitude, end.coordinate.longitude, start.coordinate.latitude, start.coordinate.longitude];
         }
         return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];
+    } else if (mapApp == CMMapAppUber) {
+        NSString *url = nil;
+        if (start.isCurrentLocation) {
+            url = [NSString stringWithFormat:@"uber://?action=setPickup&pickup=my_location&dropoff[latitude]=%f&dropoff[longitude]=%f", end.coordinate.latitude, end.coordinate.longitude];
+        } else {
+            url = [NSString stringWithFormat:@"uber://?action=setPickup&pickup[latitude]=%f&pickup[longitude]=%f&dropoff[latitude]=%f&dropoff[longitude]=%f", start.coordinate.latitude, start.coordinate.longitude, end.coordinate.latitude, end.coordinate.longitude];
+        }
     }
-    
     return NO;
 }
 
@@ -237,7 +246,7 @@
     if (_isCurrentLocation) {
         return @"Current Location";
     }
-    
+
     return _name;
 }
 
@@ -245,9 +254,9 @@
     if (_isCurrentLocation) {
         return [MKMapItem mapItemForCurrentLocation];
     }
-    
+
     MKPlacemark *placemark = [[MKPlacemark alloc] initWithCoordinate:_coordinate addressDictionary:nil];
-    
+
     MKMapItem *item = [[MKMapItem alloc] initWithPlacemark:placemark];
     item.name = self.name;
     return item;

--- a/CMMapLauncher/CMMapLauncher.m
+++ b/CMMapLauncher/CMMapLauncher.m
@@ -188,10 +188,11 @@
     } else if (mapApp == CMMapAppUber) {
         NSString *url = nil;
         if (start.isCurrentLocation) {
-            url = [NSString stringWithFormat:@"uber://?action=setPickup&pickup=my_location&dropoff[latitude]=%f&dropoff[longitude]=%f", end.coordinate.latitude, end.coordinate.longitude];
+            url = [NSString stringWithFormat:@"uber://?action=setPickup&pickup=my_location&dropoff[latitude]=%f&dropoff[longitude]=%f&dropoff[nickname]=%@", end.coordinate.latitude, end.coordinate.longitude, [end.name stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
         } else {
-            url = [NSString stringWithFormat:@"uber://?action=setPickup&pickup[latitude]=%f&pickup[longitude]=%f&dropoff[latitude]=%f&dropoff[longitude]=%f", start.coordinate.latitude, start.coordinate.longitude, end.coordinate.latitude, end.coordinate.longitude];
+            url = [NSString stringWithFormat:@"uber://?action=setPickup&pickup[latitude]=%f&pickup[longitude]=%f&dropoff[latitude]=%f&dropoff[longitude]=%f&dropoff[nickname]=%@", start.coordinate.latitude, start.coordinate.longitude, end.coordinate.latitude, end.coordinate.longitude, [end.name stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
         }
+        return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];
     }
     return NO;
 }

--- a/CMMapLauncher/CMMapLauncher.m
+++ b/CMMapLauncher/CMMapLauncher.m
@@ -79,7 +79,7 @@
     }
     
     if (mapPoint.name) {
-        return [NSString stringWithFormat:@"%f,%f+(%@)", mapPoint.coordinate.latitude, mapPoint.coordinate.longitude, [CMMapLauncher urlEncode:mapPoint.name]];
+        return [NSString stringWithFormat:@"%f,%f", mapPoint.coordinate.latitude, mapPoint.coordinate.longitude];
     }
     
     return [NSString stringWithFormat:@"%f,%f", mapPoint.coordinate.latitude, mapPoint.coordinate.longitude];


### PR DESCRIPTION
The URL scheme doesn't work with the newest version of the Google Maps app (it can't find the route). Removing the map point name fixes the problem.
