### PR TITLE
Update for iOS 9: replace deprecated method.

### DIFF
--- a/CMMapLauncher/CMMapLauncher.m
+++ b/CMMapLauncher/CMMapLauncher.m
@@ -60,7 +60,7 @@
 + (NSString *)urlEncode:(NSString *)queryParam {
     // Encode all the reserved characters, per RFC 3986
     // (<http://www.ietf.org/rfc/rfc3986.txt>)
-    NSString *newString = (__bridge_transfer NSString *)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)queryParam, NULL, (CFStringRef)@"!*'();:@&=+$,/?%#[]", kCFStringEncodingUTF8);
+    NSString *newString = [queryParam stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
     
     if (newString) {
         return newString;


### PR DESCRIPTION
This PR fixes a build warning in iOS 9 by replacing the deprecated method `CFURLCreateStringByAddingPercentEscapes` with `stringByAddingPercentEncodingWithAllowedCharacters`.
